### PR TITLE
Adds a Procfile that will work with Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: go-camo --listen=0.0.0.0:$PORT -k $HMAC_KEY


### PR DESCRIPTION
Pretty self-explanatory. 

Whoever uses this needs to
1. Create an app with the https://github.com/kr/go-heroku-example buildpack
2. Set `HMAC_KEY` to whatever their key is

Here is an example of it running on Heroku:

![](https://disko-camo.herokuapp.com/5640024f97434098d5afb455c1f1fab08372a66b/687474703a2f2f692e696d6775722e636f6d2f3057676a362e676966)
