### PR TITLE
examples: Rename Go files to avoid build failure on Heroku

### DIFF
--- a/examples/go-base64.go
+++ b/examples/go-base64.go
@@ -1,4 +1,5 @@
 // +build ignore
+
 package main
 
 import (

--- a/examples/go-hex.go
+++ b/examples/go-hex.go
@@ -1,4 +1,5 @@
 // +build ignore
+
 package main
 
 import (


### PR DESCRIPTION
Currently the build fails with:

```
-----> Running: godep go install -tags heroku ./...
# github.com/cactus/go-camo/examples
examples/go-hex.go:11: CAMO_HOST redeclared in this block
        previous declaration at examples/go-base64.go:11
examples/go-hex.go:13: GenCamoUrl redeclared in this block
        previous declaration at examples/go-base64.go:17
examples/go-hex.go:26: main redeclared in this block
        previous declaration at examples/go-base64.go:30
godep: go exit status 2
```
