### PR TITLE
Potential resource leak by not closing the response body

### DIFF
--- a/src/go-camo/camo/proxy.go
+++ b/src/go-camo/camo/proxy.go
@@ -166,6 +166,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	mlog.Debugm("built outgoing request", mlog.Map{"req": nreq})
 
 	resp, err := p.client.Do(nreq)
+
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
 	if err != nil {
 		mlog.Debugm("could not connect to endpoint", mlog.Map{"err": err})
 		// this is a bit janky, but better than peeling off the
@@ -186,7 +191,6 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
-	defer resp.Body.Close()
 
 	mlog.Debugm("response from upstream", mlog.Map{"resp": resp})
 


### PR DESCRIPTION
The http client should always close the response body - even when there is an error.  See [this link](http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#close_http_resp_body):

> Most of the time when your http request fails the resp variable will be nil and the err variable will be non-nil. However, when you get a redirection failure both variables will be non-nil. This means you can still end up with a leak.

In addition, in order to be able to reuse the connection (if keep alive is enabled on the backend), the client should read and discard the remaining response data.