### PR TITLE
fix(README): `HMAC_KEY` -> `GOCAMO_HMAC`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ In order to use this on Heroku with the provided Procfile, you need to:
 
 1.  Create an app specifying the https://github.com/kr/heroku-buildpack-go
     buildpack
-2.  Set `HMAC_KEY` to the key you are using
+2.  Set `GOCAMO_HMAC` to the key you are using
 
 ## Securing an installation
 


### PR DESCRIPTION
`HMAC_KEY` does not seem to be used anywhere in the source.
The `GOCAMO_HMAC` environment variable is being used.