### PR TITLE
Allow server name configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: go
 script: make test
 sudo: false
 go:
-    - "1.9.x"
     - "1.10.x"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 
 ## HEAD
+*   add flag to allow `video/*` as content type (disabled by default)
 
 ## 1.0.18 2018-05-15
 *   change repo layout and build pipeline to dep/gox/GOPATH style

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,15 @@ GOVER             := $(shell go version | awk '{print $$3}' | tr -d '.')
 # app specific info
 APP_NAME          := go-camo
 APP_VER           := $(shell git describe --always --dirty --tags|sed 's/^v//')
+GIT_SHA           := $(shell git log --pretty=format:'%h' -n 1)
+SERVER_COMMIT_SHA := main.ServerCommitSha
 VERSION_VAR       := main.ServerVersion
 
 # flags and build configuration
 GOTEST_FLAGS      := -cpu=1,2
 GOBUILD_DEPFLAGS  := -tags netgo
 GOBUILD_LDFLAGS   ?= -s -w
-GOBUILD_FLAGS     := ${GOBUILD_DEPFLAGS} -ldflags "${GOBUILD_LDFLAGS} -X ${VERSION_VAR}=${APP_VER}"
+GOBUILD_FLAGS     := ${GOBUILD_DEPFLAGS} -ldflags "${GOBUILD_LDFLAGS} -X ${VERSION_VAR}=${APP_VER} -X ${SERVER_COMMIT_SHA}=${GIT_SHA}"
 
 # cross compile defs
 CC_BUILD_ARCHES    = darwin/amd64 freebsd/amd64 linux/amd64

--- a/pkg/camo/misc.go
+++ b/pkg/camo/misc.go
@@ -7,6 +7,8 @@ package camo
 import (
 	"net"
 	"os"
+	"regexp"
+	"strings"
 	"syscall"
 )
 
@@ -67,4 +69,10 @@ func isRejectedIP(ip net.IP) bool {
 	}
 
 	return false
+}
+
+func globToRegexp(globString string) (*regexp.Regexp, error) {
+	gs := "^" + strings.Replace(globString, "*", ".*", 1) + "$"
+	c, err := regexp.Compile(strings.TrimSpace(gs))
+	return c, err
 }

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -18,11 +18,12 @@ import (
 )
 
 var camoConfig = Config{
-	HMACKey:        []byte("0x24FEEDFACEDEADBEEFCAFE"),
-	MaxSize:        5120 * 1024,
-	RequestTimeout: time.Duration(10) * time.Second,
-	MaxRedirects:   3,
-	ServerName:     "go-camo",
+	HMACKey:           []byte("0x24FEEDFACEDEADBEEFCAFE"),
+	MaxSize:           5120 * 1024,
+	RequestTimeout:    time.Duration(10) * time.Second,
+	MaxRedirects:      3,
+	ServerName:        "go-camo",
+	AllowContentVideo: false,
 }
 
 func makeReq(testURL string) (*http.Request, error) {
@@ -56,14 +57,14 @@ func processRequest(req *http.Request, status int, camoConfig Config) (*httptest
 	return record, nil
 }
 
-func makeTestReq(testURL string, status int) (*httptest.ResponseRecorder, error) {
+func makeTestReq(testURL string, status int, config Config) (*httptest.ResponseRecorder, error) {
 	req, err := makeReq(testURL)
 	if err != nil {
 		return nil, err
 	}
-	record, err := processRequest(req, status, camoConfig)
+	record, err := processRequest(req, status, config)
 	if err != nil {
-		return nil, err
+		return record, err
 	}
 	return record, nil
 }
@@ -86,7 +87,7 @@ func TestNotFound(t *testing.T) {
 func TestSimpleValidImageURL(t *testing.T) {
 	t.Parallel()
 	testURL := "http://www.google.com/images/srpr/logo11w.png"
-	record, err := makeTestReq(testURL, 200)
+	record, err := makeTestReq(testURL, 200, camoConfig)
 	if assert.Nil(t, err) {
 		// validate headers
 		assert.Equal(t, "test", record.HeaderMap.Get("X-Go-Camo"), "Expected custom response header not found")
@@ -97,105 +98,122 @@ func TestSimpleValidImageURL(t *testing.T) {
 func TestGoogleChartURL(t *testing.T) {
 	t.Parallel()
 	testURL := "http://chart.apis.google.com/chart?chs=920x200&chxl=0:%7C2010-08-13%7C2010-09-12%7C2010-10-12%7C2010-11-11%7C1:%7C0%7C0%7C0%7C0%7C0%7C0&chm=B,EBF5FB,0,0,0&chco=008Cd6&chls=3,1,0&chg=8.3,20,1,4&chd=s:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&chxt=x,y&cht=lc"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestChunkedImageFile(t *testing.T) {
 	t.Parallel()
 	testURL := "https://www.igvita.com/posts/12/spdyproxy-diagram.png"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestFollowRedirects(t *testing.T) {
 	t.Parallel()
 	testURL := "http://cl.ly/1K0X2Y2F1P0o3z140p0d/boom-headshot.gif"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestStrangeFormatRedirects(t *testing.T) {
 	t.Parallel()
 	testURL := "http://cl.ly/DPcp/Screen%20Shot%202012-01-17%20at%203.42.32%20PM.png"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestRedirectsWithPathOnly(t *testing.T) {
 	t.Parallel()
 	testURL := "http://httpbin.org/redirect-to?url=%2Fredirect-to%3Furl%3Dhttp%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo11w.png"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestFollowTempRedirects(t *testing.T) {
 	t.Parallel()
 	testURL := "http://httpbin.org/redirect-to?url=http://www.google.com/images/srpr/logo11w.png"
-	_, err := makeTestReq(testURL, 200)
+	_, err := makeTestReq(testURL, 200, camoConfig)
 	assert.Nil(t, err)
 }
 
 func TestBadContentType(t *testing.T) {
 	t.Parallel()
 	testURL := "http://httpbin.org/response-headers?Content-Type=what"
-	_, err := makeTestReq(testURL, 400)
+	_, err := makeTestReq(testURL, 400, camoConfig)
+	assert.Nil(t, err)
+}
+
+func TestVideoContentTypeAllowed(t *testing.T) {
+	t.Parallel()
+
+	camoConfigWithVideo := Config{
+		HMACKey:           []byte("0x24FEEDFACEDEADBEEFCAFE"),
+		MaxSize:           180 * 1024,
+		RequestTimeout:    time.Duration(10) * time.Second,
+		MaxRedirects:      3,
+		ServerName:        "go-camo",
+		AllowContentVideo: true,
+	}
+
+	testURL := "http://mirrors.standaloneinstaller.com/video-sample/small.mp4"
+	_, err := makeTestReq(testURL, 200, camoConfigWithVideo)
 	assert.Nil(t, err)
 }
 
 func Test404InfiniRedirect(t *testing.T) {
 	t.Parallel()
 	testURL := "http://httpbin.org/redirect/4"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404URLWithoutHTTPHost(t *testing.T) {
 	t.Parallel()
 	testURL := "/picture/Mincemeat/Pimp.jpg"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404ImageLargerThan5MB(t *testing.T) {
 	t.Parallel()
 	testURL := "http://apod.nasa.gov/apod/image/0505/larryslookout_spirit_big.jpg"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404HostNotFound(t *testing.T) {
 	t.Parallel()
 	testURL := "http://flabergasted.cx"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404OnExcludes(t *testing.T) {
 	t.Parallel()
 	testURL := "http://iphone.internal.example.org/foo.cgi"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404OnNonImageContent(t *testing.T) {
 	t.Parallel()
 	testURL := "https://github.com/atmos/cinderella/raw/master/bootstrap.sh"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404On10xIpRange(t *testing.T) {
 	t.Parallel()
 	testURL := "http://10.0.0.1/foo.cgi"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404On169Dot254Net(t *testing.T) {
 	t.Parallel()
 	testURL := "http://169.254.0.1/foo.cgi"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
@@ -203,7 +221,7 @@ func Test404On172Dot16Net(t *testing.T) {
 	t.Parallel()
 	for i := 16; i < 32; i++ {
 		testURL := "http://172.%d.0.1/foo.cgi"
-		_, err := makeTestReq(fmt.Sprintf(testURL, i), 404)
+		_, err := makeTestReq(fmt.Sprintf(testURL, i), 404, camoConfig)
 		assert.Nil(t, err)
 	}
 }
@@ -211,14 +229,14 @@ func Test404On172Dot16Net(t *testing.T) {
 func Test404On192Dot168Net(t *testing.T) {
 	t.Parallel()
 	testURL := "http://192.168.0.1/foo.cgi"
-	_, err := makeTestReq(testURL, 404)
+	_, err := makeTestReq(testURL, 404, camoConfig)
 	assert.Nil(t, err)
 }
 
 func Test404OnLocalhost(t *testing.T) {
 	t.Parallel()
 	testURL := "http://localhost/foo.cgi"
-	record, err := makeTestReq(testURL, 404)
+	record, err := makeTestReq(testURL, 404, camoConfig)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "Bad url host\n", record.Body.String(), "Expected 404 response body but got '%s' instead", record.Body.String())
 	}
@@ -228,7 +246,7 @@ func Test404OnLocalhost(t *testing.T) {
 func Test404OnLoopback(t *testing.T) {
 	t.Parallel()
 	testURL := "http://i.i.com.com/foo.cgi"
-	record, err := makeTestReq(testURL, 404)
+	record, err := makeTestReq(testURL, 404, camoConfig)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "Denylist host failure\n", record.Body.String(), "Expected 404 response body but got '%s' instead", record.Body.String())
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -5,7 +5,6 @@
 package router
 
 import (
-	"io"
 	"net/http"
 	"strings"
 )
@@ -28,11 +27,10 @@ func (dr *DumbRouter) SetHeaders(w http.ResponseWriter) {
 	h.Set("Server", dr.ServerName)
 }
 
-// RootHandler is a simple http hander for / that returns "Go-Camo"
-func (dr *DumbRouter) RootHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	// Status 200 is the default. No need to set explicitly here.
-	io.WriteString(w, dr.ServerName)
+// HealthCheckHandler is HTTP handler for confirming the backend service
+// is available from an external client, such as a load balancer.
+func (dr *DumbRouter) HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ServeHTTP fulfills the http server interface
@@ -50,13 +48,13 @@ func (dr *DumbRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if dr.StatsHandler != nil && r.URL.Path == "/status" {
-		dr.StatsHandler(w, r)
+	if r.URL.Path == "/healthcheck" {
+		dr.HealthCheckHandler(w, r)
 		return
 	}
 
-	if r.URL.Path == "/" {
-		dr.RootHandler(w, r)
+	if dr.StatsHandler != nil && r.URL.Path == "/status" {
+		dr.StatsHandler(w, r)
 		return
 	}
 


### PR DESCRIPTION
This introduces a couple of changes related to the server name.

The first is that it allows you to override the server name of `go-camo` using a start up flag of `--server-name`. The second is that it will now append the git sha of the latest build to the server name if it is defined and this has been great for us to perform some debugging/comparison between versions and be certain we are getting the correct outcomes.

Finally, this also updates the root route to return a 404 instead of a 200 with the server name. The thinking here is that as an image proxy, it should 404 unless it finds a resource to proxy (unless explicitly intended).