### PR TITLE
Use HTTP 200 instead of 204 for `/healthcheck`

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -30,7 +30,7 @@ func (dr *DumbRouter) SetHeaders(w http.ResponseWriter) {
 // HealthCheckHandler is HTTP handler for confirming the backend service
 // is available from an external client, such as a load balancer.
 func (dr *DumbRouter) HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(204)
+	w.WriteHeader(200)
 }
 
 // ServeHTTP fulfills the http server interface


### PR DESCRIPTION
While testing the upgrade in two different cloud providers, I found that
both of them don't respect anything other than HTTP 200 as a successful
ping check (including the rest of the 2xx range).

To accomodate for the two providers, let's just use a HTTP 200 to save
people doing hacky TCP checks instead.