### PR TITLE
Ignore port when filtering IPs and Hostnames

### DIFF
--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -242,6 +242,15 @@ func Test404OnLocalhost(t *testing.T) {
 	}
 }
 
+func Test404OnLocalhostWithPort(t *testing.T) {
+	t.Parallel()
+	testURL := "http://localhost:80/foo.cgi"
+	record, err := makeTestReq(testURL, 404, camoConfig)
+	if assert.Nil(t, err) {
+		assert.Equal(t, "Bad url host\n", record.Body.String(), "Expected 404 response body but got '%s' instead", record.Body.String())
+	}
+}
+
 // Test will fail if dns relay implements dns rebind prevention
 func Test404OnLoopback(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Description

The protection against proxying requests to local IPs can be bypassed by adding a port to the hostname (i.e. http://localhost:80)
This can result in a Server Side Request Forgery (SSRF) attack, allowing an attacker that controls the URL generated to impersonate the server in making requests.
This is fixed by using the Hostname() function from net/url, which only ever returns the hostname without the port.
Please explain the changes you made here.

### Checklist

- [x] Code compiles correctly
- [x] Created tests (if appropriate)
- [x] All tests passing
- [x] Extended the README / documentation (if necessary)

