### PR TITLE
proxy: Swap "content length exceeded" exception to be a HTTP 413

### DIFF
--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -215,7 +215,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// check for too large a response
 	if resp.ContentLength > p.config.MaxSize {
 		mlog.Debugm("content length exceeded", mlog.Map{"url": sURL})
-		http.Error(w, "Content length exceeded", http.StatusNotFound)
+		http.Error(w, "Content length exceeded", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -213,7 +213,7 @@ func Test404URLWithoutHTTPHost(t *testing.T) {
 func Test404ImageLargerThan5MB(t *testing.T) {
 	t.Parallel()
 	testURL := "http://apod.nasa.gov/apod/image/0505/larryslookout_spirit_big.jpg"
-	_, err := makeTestReq(testURL, 404, camoConfig)
+	_, err := makeTestReq(testURL, 413, camoConfig)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
We've encountered a couple of cases where the content length of the
remote was over the threshold and while the error description is
helpful, the HTTP status code is not (currently a 404). Instead of
returning the "not found" status, we can update it to be a HTTP 413
which is "request entity too large". This will allow us to differentiate
resources that aren't really there and ones that are oversized.