### PR TITLE
proxy: Split out exception for missing content types

### DIFF
--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -224,8 +224,8 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		contentType := resp.Header.Get("Content-Type")
 
 		if contentType == "" {
-			mlog.Debug("Missing content-type")
-			http.Error(w, "Missing content-type", http.StatusBadRequest)
+			mlog.Debug("Empty content-type returned")
+			http.Error(w, "Empty content-type returned", http.StatusBadRequest)
 			return
 		}
 

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -221,10 +221,17 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	switch resp.StatusCode {
 	case 200:
-		// check content type
+		contentType := resp.Header.Get("Content-Type")
+
+		if contentType == "" {
+			mlog.Debug("Missing content-type")
+			http.Error(w, "Missing content-type", http.StatusBadRequest)
+			return
+		}
+
 		match := false
 		for _, re := range p.acceptTypesRe {
-			if re.MatchString(resp.Header.Get("Content-Type")) {
+			if re.MatchString(contentType) {
 				match = true
 				break
 			}


### PR DESCRIPTION
This takes the current logic for checking whether the request is for a
valid HTTP content-type and splits it into two parts. The split moves to
allow differentiation between a content-type that we don't intend to
proxy and a missing content-type as they should be handled differently.

