### PR TITLE
Allow byte range requests to support video on Safari

### DIFF
--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -220,7 +220,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 200, 206:
 		contentType := resp.Header.Get("Content-Type")
 
 		if contentType == "" {

--- a/pkg/camo/vars.go
+++ b/pkg/camo/vars.go
@@ -24,14 +24,19 @@ var ValidReqHeaders = map[string]bool{
 	// x-forwarded-for header is not blindly passed without additional custom
 	// processing
 	"X-Forwarded-For": false,
+	// required to support Safari byte range requests for video
+	"Range": true,
 }
 
 // ValidRespHeaders are http response headers that are acceptable to pass from
 // the remote server to the client. Only those present and true, are forwarded.
 // Empty implies no filtering.
 var ValidRespHeaders = map[string]bool{
-	// Do not offer to accept range requests
-	"Accept-Ranges":    false,
+	// required to support Safari byte range requests for video
+	"Accept-Ranges":  true,
+	"Content-Length": true,
+	"Content-Range":  true,
+
 	"Cache-Control":    true,
 	"Content-Encoding": true,
 	"Content-Type":     true,


### PR DESCRIPTION
### Description

Safari requires the server to respond to byte range requests in order to display video.  I've added the necessary header values to `ValidReqHeaders` and `ValidRespHeaders` that need to be passed through, as well as handled the `206` status code that needs to get passed through on the response.

At the moment, it behaves the same as the `200` status code.

This is related to issue https://github.com/cactus/go-camo/issues/36

### Checklist

- [x] Code compiles correctly
- [ ] Created tests (if appropriate)
- [ ] All tests passing
- [ ] Extended the README / documentation (if necessary)