### PR TITLE
Provide an explicit deny URL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Application Options:
       --ssl-key=               ssl private key (key.pem) path
       --ssl-cert=              ssl cert (cert.pem) path
       --allow-list=            Text file of hostname allow regexes (one per line)
+      --deny-list=             Text file of URLs to explicitly deny access to (one per line)
       --listen=                Address:Port to bind to for HTTP (default: 0.0.0.0:8080)
       --ssl-listen=            Address:Port to bind to for HTTPS/SSL/TLS
       --max-size=              Max allowed response size (KB) (default: 5120)
@@ -258,6 +259,10 @@ Help Options:
 If an allow-list file is defined, that file is read and each line converted
 into a hostname regex. If a request does not match one of the listed host
 regex, then the request is denied.
+
+If a deny-list file is defined, that file is read and each line compared
+to the outgoing request. If any part of the URL matches, the request is
+denied.
 
 If metrics flag is provided, then the service will expose a Prometheus `/metrics` endpoint.
 

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -58,6 +58,7 @@ func main() {
 		SSLKey              string        `long:"ssl-key" description:"ssl private key (key.pem) path"`
 		SSLCert             string        `long:"ssl-cert" description:"ssl cert (cert.pem) path"`
 		AllowList           string        `long:"allow-list" description:"Text file of hostname allow regexes (one per line)"`
+		DenyList            string        `long:"deny-list" description:"Text file of URLs to explicitly deny access to (one per line)"`
 		BindAddress         string        `long:"listen" default:"0.0.0.0:8080" description:"Address:Port to bind to for HTTP"`
 		BindAddressSSL      string        `long:"ssl-listen" description:"Address:Port to bind to for HTTPS/SSL/TLS"`
 		MaxSize             int64         `long:"max-size" default:"5120" description:"Max allowed response size (KB)"`
@@ -152,6 +153,14 @@ func main() {
 			mlog.Fatal("Could not read allow-list", err)
 		}
 		config.AllowList = strings.Split(string(b), "\n")
+	}
+
+	if opts.DenyList != "" {
+		b, err := ioutil.ReadFile(opts.DenyList)
+		if err != nil {
+			mlog.Fatal("Could not read deny-list", err)
+		}
+		config.DenyList = strings.Split(string(b), "\n")
 	}
 
 	AddHeaders := map[string]string{

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -30,6 +30,24 @@ var camoConfig = Config{
 	AllowCredetialURLs: false,
 }
 
+var camoConfigWithExplicitHostnameDeny = Config{
+	HMACKey:        []byte("0x24FEEDFACEDEADBEEFCAFE"),
+	MaxSize:        5120 * 1024,
+	RequestTimeout: time.Duration(10) * time.Second,
+	MaxRedirects:   3,
+	ServerName:     "go-camo",
+	DenyList:       []string{"images.anandtech.com"},
+}
+
+var camoConfigWithExplicitURLDeny = Config{
+	HMACKey:        []byte("0x24FEEDFACEDEADBEEFCAFE"),
+	MaxSize:        5120 * 1024,
+	RequestTimeout: time.Duration(10) * time.Second,
+	MaxRedirects:   3,
+	ServerName:     "go-camo",
+	DenyList:       []string{"https://images.anandtech.com/doci/6673/OpenMoboAMD30_575px.png"},
+}
+
 func makeReq(testURL string) (*http.Request, error) {
 	k := []byte(camoConfig.HMACKey)
 	hexURL := encoding.B64EncodeURL(k, testURL)
@@ -375,6 +393,24 @@ func TestSupplyAcceptIfNoneGiven(t *testing.T) {
 	req.Header.Del("Accept")
 	assert.Nil(t, err)
 	_, err = processRequest(req, 200, camoConfig)
+	assert.Nil(t, err)
+}
+
+func TestExplicitDenyWithHostname(t *testing.T) {
+	t.Parallel()
+	testURL := "https://images.anandtech.com/doci/6673/OpenMoboAMD30_575px.png"
+	req, err := makeReq(testURL)
+	assert.Nil(t, err)
+	_, err = processRequest(req, 404, camoConfigWithExplicitHostnameDeny)
+	assert.Nil(t, err)
+}
+
+func TestExplicitDenyWithFullURL(t *testing.T) {
+	t.Parallel()
+	testURL := "https://images.anandtech.com/doci/6673/OpenMoboAMD30_575px.png"
+	req, err := makeReq(testURL)
+	assert.Nil(t, err)
+	_, err = processRequest(req, 404, camoConfigWithExplicitURLDeny)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
Camo currently ships with the option to provide a file path containing a
number of hostnames to `--allow-list` which limits where images will be
proxied from. This works great for restricting the source if you control
the origin or have a small number of origins.

What it doesn't cover very well is to explicitly deny access to a
resource on a fine grained level. Take for example, you use Camo to
proxy all third party assets to put a CDN in front of them and then one
of the origins used via Camo is hosting malicious or inappropriate
material. There currently isn't a sane way of preventing access to this
particular resource once anyone has the signed HMAC URL. There are work
arounds to kill the connection however they require drastic action like
rolling the HMAC which unless co-ordinated well, results in a service
interruption.

This change aims to address the above scenario by exposing a way to
define the inverse, an explicit deny list. It works on a similar
principle to the `allow-list` with one notable exception; it loosely
matches the outgoing URL. Instead of restricting based on hostname or
asset filename, it can match anywhere using `string.Contains`. This
brings with it great power and a potential to shoot yourself in the foot
if misconfigured. The thought behind this is that Re2 is pretty poor at
operations like negative lookaheads (specifically because it [conflicts
with the O(n)-time guarantees of the library](https://groups.google.com/forum/#!topic/golang-nuts/7qgSDWPIh_E)) and I didn't want to
overload options with variants for hostname, path, etc. An added benefit
to this approach is that you're able to deny a single resource on a
domain and not the whole domain which is useful for shared image hosting
services.