### PR TITLE
Add additional metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ SIGN_KEY          ?= ${HOME}/.minisign/go-camo.key
 # app specific info
 APP_NAME          := go-camo
 APP_VER           := $(shell git describe --always --tags|sed 's/^v//')
+BRANCH_VAR        := github.com/prometheus/common/version.Branch
+BRANCH            ?= $(shell git rev-parse --abbrev-ref HEAD)
+REVISION_VAR      := github.com/prometheus/common/version.Revision
+REVISION          ?= $(shell git rev-parse HEAD)
 VERSION_VAR       := main.ServerVersion
 
 # flags and build configuration
@@ -16,7 +20,7 @@ GOBUILD_OPTIONS   := -trimpath
 GOTEST_FLAGS      := -cpu=1,2
 GOBUILD_DEPFLAGS  := -tags netgo
 GOBUILD_LDFLAGS   ?= -s -w
-GOBUILD_FLAGS     := ${GOBUILD_DEPFLAGS} ${GOBUILD_OPTIONS} -ldflags "${GOBUILD_LDFLAGS} -X ${VERSION_VAR}=${APP_VER}"
+GOBUILD_FLAGS     := ${GOBUILD_DEPFLAGS} ${GOBUILD_OPTIONS} -ldflags "${GOBUILD_LDFLAGS} -X ${BRANCH_VAR}=${BRANCH} -X ${REVISION_VAR}=${REVISION} -X ${VERSION_VAR}=${APP_VER}"
 
 # cross compile defs
 CC_BUILD_ARCHES    = darwin/amd64 freebsd/amd64 linux/amd64

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ go-camo
 *   [Running on Heroku](#running-on-heroku)
 *   [Securing an installation](#securing-an-installation)
 *   [Configuring](#configuring)
+*   [Monitoring](#monitoring)
 *   [Additional tools](#additional-tools)
 *   [Containers](#containers)
 *   [Alternative Implementations](#alternative-implementations)
@@ -316,6 +317,25 @@ A few notes about specific flags:
     ```text
     -H "Strict-Transport-Security:  max-age=16070400"
     ```
+
+## Monitoring
+
+### Metrics
+
+When the `--metrics` flag is used, the service will expose a Prometheus-compatible `/metrics` endpoint. This can be used by monitoring systems to gather data.
+
+The endpoint includes all of the default `go_` and `process_`. In addition, a number of custom metrics.
+
+| Name                                     | Type      | Help |
+| ---------------------------------------- | --------- | ---- |
+| camo_response_duration_seconds           | Histogram | A histogram of latencies for proxy responses. |
+| camo_response_size_bytes                 | Histogram | A histogram of sizes for proxy responses. |
+| camo_proxy_content_length_exceeded_total | Counter   | The number of requests where the content length was exceeded. |
+| camo_proxy_reponses_failed_total         | Counter   | The number of responses that failed to send to the client. |
+| camo_proxy_reponses_truncated_total      | Counter   | The number of responess that were too large to send. |
+| camo_responses_total                     | Counter   | Total HTTP requests processed by the go-camo, excluding scrapes. |
+
+It also includes a `camo_build_info` metric that exposes the version, git branch/revision, and Go version used to build the server.
 
 ## Additional tools
 

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -34,7 +34,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: camo.MetricNamespace,
 			Name:      "response_size_bytes",
-			Help:      "A histogram of response sizes for requests.",
+			Help:      "A histogram of sizes for proxy responses.",
 			Buckets:   prometheus.ExponentialBuckets(1024, 2, 10),
 		},
 		[]string{},
@@ -43,7 +43,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: camo.MetricNamespace,
 			Name:      "response_duration_seconds",
-			Help:      "A histogram of latencies for requests.",
+			Help:      "A histogram of latencies for proxy responses.",
 			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/cactus/mlog v1.0.3
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/common v0.6.0
 	github.com/stretchr/testify v1.4.0
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
 	golang.org/x/net v0.0.0-20190921015927-1a5e07d1ff72

--- a/pkg/camo/misc.go
+++ b/pkg/camo/misc.go
@@ -13,6 +13,9 @@ import (
 	"syscall"
 )
 
+// Namespace used for Prometheus metrics.
+const MetricNamespace = "camo"
+
 type LimitReadCloser struct {
 	io.ReadCloser
 	io.Reader


### PR DESCRIPTION
### Description

Add additional metrics:

* Response counter with code/method labels.
* Content length exceeded counter.
* Failed proxy responses.
* Truncated proxy responses.
* Build + version info.

Example output:
```
# HELP camo_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which camo was built.
# TYPE camo_build_info gauge
camo_build_info{branch="more_metrics",goversion="go1.13",revision="17c52efa9e174dbcefe8a3403aa915d9fb8ca16d",version="2.0.1-18-g17c52ef"} 1
# HELP camo_proxy_content_length_exceeded_total The number of requests where the content length was exceeded.
# TYPE camo_proxy_content_length_exceeded_total counter
camo_proxy_content_length_exceeded_total 0
# HELP camo_proxy_reponses_failed_total The number of responses that failed to send to the client.
# TYPE camo_proxy_reponses_failed_total counter
camo_proxy_reponses_failed_total 0
# HELP camo_proxy_reponses_truncated_total The number of responess that were too large to send.
# TYPE camo_proxy_reponses_truncated_total counter
camo_proxy_reponses_truncated_total 0
# HELP camo_responses_total Total HTTP requests processed by the go-camo, excluding scrapes.
# TYPE camo_responses_total counter
camo_responses_total{code="404",method="get"} 1
```

### Checklist

- [x] Code compiles correctly
- [ ] Created tests (if appropriate)
- [x] All tests passing
- [ ] Extended the README / documentation (if necessary)

