### PR TITLE
support allowing audio content

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Application Options:
       --no-fk                  Disable frontend http keep-alive support
       --no-bk                  Disable backend http keep-alive support
       --allow-content-video    Additionally allow 'video/*' content
+      --allow-content-audio    Additionally allow 'audio/*' content
       --allow-credential-urls  Allow urls to contain user/pass credentials
       --filter-ruleset=        Text file containing filtering rules (one per line)
       --server-name=           Value to use for the HTTP server field (default: go-camo)

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -135,6 +135,7 @@ func main() {
 		DisableKeepAlivesFE bool          `long:"no-fk" description:"Disable frontend http keep-alive support"`
 		DisableKeepAlivesBE bool          `long:"no-bk" description:"Disable backend http keep-alive support"`
 		AllowContentVideo   bool          `long:"allow-content-video" description:"Additionally allow 'video/*' content"`
+		AllowContentAudio   bool          `long:"allow-content-audio" description:"Additionally allow 'audio/*' content"`
 		AllowCredetialURLs  bool          `long:"allow-credential-urls" description:"Allow urls to contain user/pass credentials"`
 		FilterRuleset       string        `long:"filter-ruleset" description:"Text file containing filtering rules (one per line)"`
 		ServerName          string        `long:"server-name" default:"go-camo" description:"Value to use for the HTTP server field"`
@@ -214,6 +215,7 @@ func main() {
 
 	// additional content types to allow
 	config.AllowContentVideo = opts.AllowContentVideo
+	config.AllowContentAudio = opts.AllowContentAudio
 
 	var filters []camo.FilterFunc
 	if opts.FilterRuleset != "" {

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -42,6 +42,7 @@ type Config struct {
 	EnableXFwdFor bool
 	// additional content types to allow
 	AllowContentVideo bool
+	AllowContentAudio bool
 	// allow URLs to contain user/pass credentials
 	AllowCredetialURLs bool
 	// no ip filtering (test mode)
@@ -433,6 +434,9 @@ func New(pc Config) (*Proxy, error) {
 	// add additional accept types, if appropriate
 	if pc.AllowContentVideo {
 		acceptTypes = append(acceptTypes, "video/*")
+	}
+	if pc.AllowContentAudio {
+		acceptTypes = append(acceptTypes, "audio/*")
 	}
 
 	// re-use the htrie glob path checker for accept types validation

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -162,6 +162,31 @@ func TestVideoContentTypeAllowed(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestAudioContentTypeAllowed(t *testing.T) {
+	t.Parallel()
+
+	camoConfigWithAudio := Config{
+		HMACKey:           []byte("0x24FEEDFACEDEADBEEFCAFE"),
+		MaxSize:           180 * 1024,
+		RequestTimeout:    time.Duration(10) * time.Second,
+		MaxRedirects:      3,
+		ServerName:        "go-camo",
+		AllowContentAudio: true,
+	}
+
+	testURL := "https://actions.google.com/sounds/v1/alarms/alarm_clock.ogg"
+	_, err := makeTestReq(testURL, 200, camoConfigWithAudio)
+	assert.Nil(t, err)
+
+	// try a range request
+	req, err := makeReq(camoConfigWithAudio, testURL)
+	assert.Nil(t, err)
+	req.Header.Add("Range", "bytes=0-10")
+	resp, err := processRequest(req, 206, camoConfigWithAudio, nil)
+	assert.Equal(t, resp.Header.Get("Content-Range"), "bytes 0-10/49872")
+	assert.Nil(t, err)
+}
+
 func TestCredetialURLsAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/htrie/glob_path_chk_test.go
+++ b/pkg/htrie/glob_path_chk_test.go
@@ -75,12 +75,14 @@ func TestGlobPathCheckerPathsMisc(t *testing.T) {
 	rules := []string{
 		"|i|image/*",
 		"||video/mp4",
+		"||audio/ogg",
 		"||pickle/dill+brine",
 	}
 
 	testMatch := []string{
 		"image/png",
 		"video/mp4",
+		"audio/ogg",
 		"pickle/dill+brine",
 	}
 
@@ -92,6 +94,8 @@ func TestGlobPathCheckerPathsMisc(t *testing.T) {
 		"ximage/png\n",
 		"VIDEO/mp4",
 		"xVIDEO/mp4",
+		"AUDIO/ogg",
+		"xAUDIO/ogg",
 		"pickle/dill+briney",
 		"pickley/dilly+brine",
 	}


### PR DESCRIPTION
### Description

This addition would provide an option for allowing audio content as well.

The use case would be for a feature in Gitlab supporting [embedded audio in markdown](https://gitlab.com/gitlab-org/gitlab/merge_requests/17860).

As with Github, Gitlab allows users to provide embedded images in markdown:
[`![my image](http://example.com/my_image.jpg)`](https://gitlab.com/gitlab-org/gitlab/blob/master/doc/user/markdown.md#images)

Additionally, Gitlab permits embedded video, using the same syntax:
[`![my video](http://example.com/my_video.mp4)`](https://gitlab.com/gitlab-org/gitlab/blob/master/doc/user/markdown.md#videos)

As they use go-camo as their proxy for these assets, which now supports video, all of this works.

Just this week, I submitted a merge request to allow embedded audio, not  knowing about this constraint as it regards to the go-camo server.

I think it'd be worth supporting this extra format as it would not [expose the execution context](https://github.com/cactus/go-camo/issues/20#issuecomment-340595332) and would require only a small addition to the current code base.

I would love to hear what you think, thanks.

### Checklist

- [x] Code compiles correctly
- [x] Created tests (if appropriate)
- [x] All tests passing
- [x] Extended the README / documentation (if necessary)

