### PR TITLE
Pass config by reference into New methods

### DIFF
--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -277,7 +277,7 @@ func main() {
 	config.MaxRedirects = opts.MaxRedirects
 	config.ServerName = ServerName
 
-	proxy, err := camo.NewWithFilters(config, filters)
+	proxy, err := camo.NewWithFilters(&config, filters)
 	if err != nil {
 		mlog.Fatal("Error creating camo", err)
 	}

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -421,7 +421,7 @@ func (p *Proxy) copyHeaders(dst, src *http.Header, filter *map[string]bool) {
 // NewWithFilters returns a new Proxy that utilises the passed in proxy filters.
 // filters are evaluated in order, and the first false response from a filter
 // function halts further evaluation and fails the request.
-func NewWithFilters(pc Config, filters []FilterFunc) (*Proxy, error) {
+func NewWithFilters(pc *Config, filters []FilterFunc) (*Proxy, error) {
 	proxy, err := New(pc)
 	if err != nil {
 		return nil, err
@@ -441,7 +441,7 @@ func NewWithFilters(pc Config, filters []FilterFunc) (*Proxy, error) {
 }
 
 // New returns a new Proxy. Returns an error if Proxy could not be constructed.
-func New(pc Config) (*Proxy, error) {
+func New(pc *Config) (*Proxy, error) {
 	tr := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   3 * time.Second,
@@ -500,7 +500,7 @@ func New(pc Config) (*Proxy, error) {
 
 	p := &Proxy{
 		client:            client,
-		config:            &pc,
+		config:            pc,
 		acceptTypesString: strings.Join(acceptTypes, ", "),
 		acceptTypesFilter: acceptTypesFilter,
 	}


### PR DESCRIPTION
Without this, the setting of 'CollectMetrics' after constructing the proxy
does not work as expected (it is setting it on the original Config, not
the copy that the proxy now has)

The underlyling bug could also be fixed by setting CollectMetrics before
constructing the Proxy, but this seems like a reasonable way to make it work
and be more robust as well (for the future)

### Description
Pass the Config object around by reference, not by value, so that metrics get enabled as expected

### Checklist

- [ ] Code compiles correctly
- [ ] Created tests (if appropriate)
- [ ] All tests passing
- [ ] Extended the README / documentation (if necessary)

