### PR TITLE
Move the setting of CollectMetrics to before constructing the Proxy

### DIFF
--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -276,6 +276,9 @@ func main() {
 	config.RequestTimeout = opts.ReqTimeout
 	config.MaxRedirects = opts.MaxRedirects
 	config.ServerName = ServerName
+	if opts.Metrics {
+		config.CollectMetrics = true
+  }
 
 	proxy, err := camo.NewWithFilters(config, filters)
 	if err != nil {
@@ -289,7 +292,6 @@ func main() {
 	}
 
 	if opts.Metrics {
-		config.CollectMetrics = true
 		mlog.Printf("Enabling metrics at /metrics")
 		http.Handle("/metrics", promhttp.Handler())
 		// Register a version info metric.


### PR DESCRIPTION
It's not possible to move the entire Metrics setup to before the proxy
because it needs the router (which needs the proxy)

### Description
Ensures collecting of metrics actually works

### Checklist

- [ ] Code compiles correctly
- [ ] Created tests (if appropriate)
- [ ] All tests passing
- [ ] Extended the README / documentation (if necessary)

