### PR TITLE
Structured JSON logging

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -300,6 +300,7 @@ Application Options:
       --max-redirects=         Maximum number of redirects to follow (default: 3)
       --metrics                Enable Prometheus compatible metrics endpoint
       --no-log-ts              Do not add a timestamp to logging
+      --log-json               Log in JSON format
       --no-fk                  Disable frontend http keep-alive support
       --no-bk                  Disable backend http keep-alive support
       --allow-content-video    Additionally allow 'video/*' content

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -144,6 +144,7 @@ func main() {
 		MaxRedirects        int           `long:"max-redirects" default:"3" description:"Maximum number of redirects to follow"`
 		Metrics             bool          `long:"metrics" description:"Enable Prometheus compatible metrics endpoint"`
 		NoLogTS             bool          `long:"no-log-ts" description:"Do not add a timestamp to logging"`
+		LogJson             bool          `long:"log-json" description:"Log in JSON format"`
 		DisableKeepAlivesFE bool          `long:"no-fk" description:"Disable frontend http keep-alive support"`
 		DisableKeepAlivesBE bool          `long:"no-bk" description:"Disable backend http keep-alive support"`
 		AllowContentVideo   bool          `long:"allow-content-video" description:"Additionally allow 'video/*' content"`
@@ -270,6 +271,10 @@ func main() {
 	if opts.Verbose {
 		mlog.SetFlags(mlog.Flags() | mlog.Ldebug)
 		mlog.Debug("debug logging enabled")
+	}
+
+	if opts.LogJson {
+		mlog.SetEmitter(&mlog.FormatWriterJSON{})
 	}
 
 	// convert from KB to Bytes

--- a/pkg/camo/log.go
+++ b/pkg/camo/log.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2012-2019 Eli Janssen
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Package camo provides an HTTP proxy server with content type
+// restrictions as well as regex host allow list support.
+package camo
+
+import (
+	"net/http"
+
+	"github.com/cactus/mlog"
+)
+
+func httpReqToMlogMap(req *http.Request) mlog.Map {
+	return mlog.Map{
+		"method":            req.Method,
+		"path":              req.RequestURI,
+		"proto":             req.Proto,
+		"header":            req.Header,
+		"content_length":    req.ContentLength,
+		"transfer_encoding": req.TransferEncoding,
+		"host":              req.Host,
+		"remote_addr":       req.RemoteAddr,
+	}
+}
+
+func httpRespToMlogMap(resp *http.Response) mlog.Map {
+	return mlog.Map{
+		"status":            resp.StatusCode,
+		"proto":             resp.Proto,
+		"header":            resp.Header,
+		"content_length":    resp.ContentLength,
+		"transfer_encoding": resp.TransferEncoding,
+	}
+}

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -94,7 +94,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	sigHash, encodedURL := components[1], components[2]
 
 	if mlog.HasDebug() {
-		mlog.Debugm("client request", mlog.Map{"req": req})
+		mlog.Debugm("client request", httpReqToMlogMap(req))
 	}
 
 	sURL, ok := encoding.DecodeURL(p.config.HMACKey, sigHash, encodedURL)
@@ -160,7 +160,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	nreq.Header.Add("Via", p.config.ServerName)
 
 	if mlog.HasDebug() {
-		mlog.Debugm("built outgoing request", mlog.Map{"req": nreq})
+		mlog.Debugm("built outgoing request", mlog.Map{"req": httpReqToMlogMap(nreq)})
 	}
 
 	resp, err := p.client.Do(nreq)
@@ -174,7 +174,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		case errors.Is(err, context.Canceled):
 			// handle client aborting request early in the request lifetime
 			if mlog.HasDebug() {
-				mlog.Debugm("client aborted request (early)", mlog.Map{"req": req})
+				mlog.Debugm("client aborted request (early)", httpReqToMlogMap(req))
 			}
 			return
 		case errors.Is(err, ErrRedirect):
@@ -227,7 +227,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if mlog.HasDebug() {
-		mlog.Debugm("response from upstream", mlog.Map{"resp": resp})
+		mlog.Debugm("response from upstream", httpRespToMlogMap(resp))
 	}
 
 	// check for too large a response
@@ -577,4 +577,27 @@ func New(pc Config) (*Proxy, error) {
 	}
 
 	return p, nil
+}
+
+func httpReqToMlogMap(req *http.Request) mlog.Map {
+	return mlog.Map{
+		"method":            req.Method,
+		"path":              req.RequestURI,
+		"proto":             req.Proto,
+		"header":            req.Header,
+		"content_length":    req.ContentLength,
+		"transfer_encoding": req.TransferEncoding,
+		"host":              req.Host,
+		"remote_addr":       req.RemoteAddr,
+	}
+}
+
+func httpRespToMlogMap(resp *http.Response) mlog.Map {
+	return mlog.Map{
+		"status":            resp.StatusCode,
+		"proto":             resp.Proto,
+		"header":            resp.Header,
+		"content_length":    resp.ContentLength,
+		"transfer_encoding": resp.TransferEncoding,
+	}
 }

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -578,26 +578,3 @@ func New(pc Config) (*Proxy, error) {
 
 	return p, nil
 }
-
-func httpReqToMlogMap(req *http.Request) mlog.Map {
-	return mlog.Map{
-		"method":            req.Method,
-		"path":              req.RequestURI,
-		"proto":             req.Proto,
-		"header":            req.Header,
-		"content_length":    req.ContentLength,
-		"transfer_encoding": req.TransferEncoding,
-		"host":              req.Host,
-		"remote_addr":       req.RemoteAddr,
-	}
-}
-
-func httpRespToMlogMap(resp *http.Response) mlog.Map {
-	return mlog.Map{
-		"status":            resp.StatusCode,
-		"proto":             resp.Proto,
-		"header":            resp.Header,
-		"content_length":    resp.ContentLength,
-		"transfer_encoding": resp.TransferEncoding,
-	}
-}


### PR DESCRIPTION
### Description

GitLab SRE here. :)

This patch introduces support for logging in JSON format (via new `--log-json` flag), and also changes the request logging to be properly structured.

This allows for easier diagnosis when there is an issue in production, as we can parse the fields out into Elasticsearch (or other log processing tools) and filter on them.

Before:

```
{"time": "2021-05-11T17:26:16.493664000+02:00", "level": "D", "msg": "client request", "extra": {"req": "&{GET /a/b HTTP/1.1 1 1 map[Accept:[*/*] User-Agent:[curl/7.64.1] Via:[go-camo]] {} <nil> 0 [] false go-camo map[] map[] <nil> map[] 127.0.0.1:52466 /a/b <nil> <nil> <nil> 0xc000030e80}"}}
```

After:

```
{"time": "2021-05-11T17:33:44.199222000+02:00", "level": "D", "msg": "client request", "extra": {"proto": "HTTP/1.1", "header": "map[Accept:[*/*] User-Agent:[curl/7.64.1] Via:[go-camo]]", "transfer_encoding": "[]","method": "GET", "path": "/a/b", "content_length": "0", "host": "go-camo", "remote_addr": "127.0.0.1:52613"}}
```

There's still room for improvement wrt nested maps, but this is already a lot more machine friendly.

### Checklist

- [x] Code compiles correctly
- [ ] Created tests (if appropriate)
- [x] All tests passing
- [x] Extended the README / documentation (if necessary)

