### PR TITLE
Download

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -134,6 +134,8 @@ Note that it is recommended to front Go-Camo with a CDN when possible.
 *   Go-Camo supports HTTP HEAD requests.
 *   Go-Camo allows custom default headers to be added --
     useful for things like adding {link-hsts} headers.
+*   Go-Camo supports appending `/download` to make browsers
+    download, instead of display, the content.
 
 == Installing pre-built binaries
 

--- a/cmd/url-tool/main.go
+++ b/cmd/url-tool/main.go
@@ -21,6 +21,7 @@ import (
 type EncodeCommand struct {
 	Base       string `short:"b" long:"base" default:"hex" description:"Encode/Decode base. Either hex or base64"`
 	Prefix     string `short:"p" long:"prefix" default:"" description:"Optional url prefix used by encode output"`
+	Attachment bool   `short:"d" long:"download" description:"If set, the URL will have 'Content-Disposition: attachment' set"`
 	Positional struct {
 		Url string `positional-arg-name:"URL"`
 	} `positional-args:"yes" required:"true"`
@@ -45,6 +46,9 @@ func (c *EncodeCommand) Execute(args []string) error {
 		outURL = encoding.HexEncodeURL(hmacKeyBytes, c.Positional.Url)
 	default:
 		return errors.New("invalid base provided")
+	}
+	if c.Attachment {
+		outURL += "/download"
 	}
 	fmt.Println(strings.TrimRight(c.Prefix, "/") + outURL)
 	return nil
@@ -73,7 +77,12 @@ func (c *DecodeCommand) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	comp := strings.SplitN(u.Path, "/", 3)
+	comp := strings.SplitN(u.Path, "/", 4)
+	if len(comp) == 4 {
+		if comp[3] != "download" {
+			return errors.New("invalid trailer")
+		}
+	}
 	decURL, valid := encoding.DecodeURL(hmacKeyBytes, comp[1], comp[2])
 	if !valid {
 		return errors.New("hmac is invalid")

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -326,7 +327,15 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// set content type based on parsed content type, not originally supplied
 	h.Set("content-type", responseContentType)
 	if attachmentDisposition {
-		h.Set("content-disposition", "attachment")
+		_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition"))
+		if err != nil {
+			params = make(map[string]string)
+		}
+		if _, ok := params["filename"]; !ok {
+			_, params["filename"] = filepath.Split(u.EscapedPath())
+		}
+		disposition := mime.FormatMediaType("attachment", params)
+		h.Set("Content-Disposition", disposition)
 	}
 	w.WriteHeader(resp.StatusCode)
 

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -88,11 +88,20 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// split path and get components
 	components := strings.Split(req.URL.Path, "/")
-	if len(components) < 3 {
+	if len(components) < 3 || len(components) > 4 {
 		http.Error(w, "Malformed request path", http.StatusNotFound)
 		return
 	}
 	sigHash, encodedURL := components[1], components[2]
+	attachmentDisposition := false
+	if len(components) == 4 {
+		if components[3] == "download" {
+			attachmentDisposition = true
+		} else {
+			http.Error(w, "Malformed request path", http.StatusNotFound)
+			return
+		}
+	}
 
 	if mlog.HasDebug() {
 		mlog.Debugm("client request", httpReqToMlogMap(req))
@@ -316,6 +325,9 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	p.copyHeaders(&h, &resp.Header, &ValidRespHeaders)
 	// set content type based on parsed content type, not originally supplied
 	h.Set("content-type", responseContentType)
+	if attachmentDisposition {
+		h.Set("content-disposition", "attachment")
+	}
 	w.WriteHeader(resp.StatusCode)
 
 	// get a []byte from bufpool, and put it back on defer

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -432,6 +432,47 @@ func Test404OnLoopback(t *testing.T) {
 	}
 }
 
+func TestDownloadDisposition(t *testing.T) {
+	t.Parallel()
+	testURL := "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Proxi%2C_Bordeaux%2C_July_2014.JPG/1200px-Proxi%2C_Bordeaux%2C_July_2014.JPG"
+	req, err := makeReq(camoConfig, testURL)
+	assert.Check(t, err)
+	resp, err := processRequest(req, 200, camoConfig, nil)
+	headerAssert(t, "", "Content-Disposition", resp)
+	assert.Check(t, err)
+
+	req.URL.Path = req.URL.Path + "/download"
+	resp, err = processRequest(req, 200, camoConfig, nil)
+	headerAssert(t, "attachment", "Content-Disposition", resp)
+	assert.Check(t, err)
+}
+
+func TestPathPieces(t *testing.T) {
+	t.Parallel()
+	testURL := "http://www.google.com/images/srpr/logo11w.png"
+	req, err := makeReq(camoConfig, testURL)
+	assert.Check(t, err)
+	req.URL.Path = req.URL.Path + "/"
+	resp, err := processRequest(req, 404, camoConfig, nil)
+	bodyAssert(t, "Malformed request path\n", resp)
+	assert.Check(t, err)
+
+	req.URL.Path = req.URL.Path + "down"
+	resp, err = processRequest(req, 404, camoConfig, nil)
+	bodyAssert(t, "Malformed request path\n", resp)
+	assert.Check(t, err)
+
+	req.URL.Path = req.URL.Path + "/load"
+	resp, err = processRequest(req, 404, camoConfig, nil)
+	bodyAssert(t, "404 Not Found\n", resp)
+	assert.Check(t, err)
+
+	req.URL.Path = "/download"
+	resp, err = processRequest(req, 404, camoConfig, nil)
+	bodyAssert(t, "404 Not Found\n", resp)
+	assert.Check(t, err)
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 

--- a/pkg/camo/proxy_test.go
+++ b/pkg/camo/proxy_test.go
@@ -443,7 +443,22 @@ func TestDownloadDisposition(t *testing.T) {
 
 	req.URL.Path = req.URL.Path + "/download"
 	resp, err = processRequest(req, 200, camoConfig, nil)
-	headerAssert(t, "attachment", "Content-Disposition", resp)
+	headerAssert(t, "attachment; filename=\"Proxi,_Bordeaux,_July_2014.JPG\"", "Content-Disposition", resp)
+	assert.Check(t, err)
+}
+
+func TestDownloadDispositionUnicode(t *testing.T) {
+	t.Parallel()
+	testURL := "https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/Aillant-sur-Tholon-FR-89-Proxi_March%C3%A9-09.jpg/1200px-Aillant-sur-Tholon-FR-89-Proxi_March%C3%A9-09.jpg"
+	req, err := makeReq(camoConfig, testURL)
+	assert.Check(t, err)
+	resp, err := processRequest(req, 200, camoConfig, nil)
+	headerAssert(t, "", "Content-Disposition", resp)
+	assert.Check(t, err)
+
+	req.URL.Path = req.URL.Path + "/download"
+	resp, err = processRequest(req, 200, camoConfig, nil)
+	headerAssert(t, "attachment; filename*=utf-8''Aillant-sur-Tholon-FR-89-Proxi_March%C3%A9-09.jpg", "Content-Disposition", resp)
 	assert.Check(t, err)
 }
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -48,7 +48,7 @@ func (dr *DumbRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	components := strings.Split(r.URL.Path, "/")
-	if len(components) == 3 {
+	if len(components) == 3 || len(components) == 4 {
 		dr.CamoHandler.ServeHTTP(w, r)
 		return
 	}


### PR DESCRIPTION
### Description

If go-camo is served from its own hostname, one cannot use `<a href="..." download>` to proxy download links through Camo, since the `download` attribute is limited to same-origin links.

Extend the URL schema to allow for a `/download` trailer, which, if set, override `Content-Disposition` to `attachment`, as well as providing a hint at the filename, either from the remote Content-Disposition header, or from the original URL.

### Checklist

- [x] Code compiles correctly
- [x] Created tests (if appropriate)
- [x] All tests passing
- [x] Extended the README / documentation (if necessary)

