### PR TITLE
Add a `--no-debug-vars` command line switch to disable the `/debug/var` endpoint

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -286,8 +286,7 @@ Usage:
 
 Application Options:
   -k, --key=                   HMAC key
-  -H, --header=                Add additional header to each response. This option can
-                               be used multiple times to add multiple headers
+  -H, --header=                Add additional header to each response. This option can be used multiple times to add multiple headers
       --listen=                Address:Port to bind to for HTTP (default: 0.0.0.0:8080)
       --ssl-listen=            Address:Port to bind to for HTTPS/SSL/TLS
       --socket-listen=         Path for unix domain socket to bind to for HTTP
@@ -297,6 +296,7 @@ Application Options:
       --timeout=               Upstream request timeout (default: 4s)
       --max-redirects=         Maximum number of redirects to follow (default: 3)
       --metrics                Enable Prometheus compatible metrics endpoint
+      --no-debug-vars          Disable the /debug/vars/ metrics endpoint. This option has no effects when the metrics are not enabled
       --no-log-ts              Do not add a timestamp to logging
       --log-json               Log in JSON format
       --no-fk                  Disable frontend http keep-alive support
@@ -359,8 +359,14 @@ The default is `0`.
 * `--metrics`
 +
 --
-If the metrics flag is provided,
-then the service will expose a Prometheus `/metrics` endpoint.
+If the `metrics` flag is provided,
+then the service will expose a Prometheus `/metrics` endpoint and a `/debug/vars` endpoint from the go `expvar` package.
+--
+
+* `--no-debug-vars`
++
+--
+If the `no-debug-vars` flag is provided along with the `metrics` flag, the `/debug/vars` endpoint is removed.
 --
 
 * `-k`, `--key`

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -161,6 +161,7 @@ func main() {
 		ReqTimeout          time.Duration `long:"timeout" default:"4s" description:"Upstream request timeout"`
 		MaxRedirects        int           `long:"max-redirects" default:"3" description:"Maximum number of redirects to follow"`
 		Metrics             bool          `long:"metrics" description:"Enable Prometheus compatible metrics endpoint"`
+		NoDebugVars         bool          `long:"no-debug-vars" description:"Disable the /debug/vars/ metrics endpoint. This option has no effects when the metrics are not enabled"`
 		NoLogTS             bool          `long:"no-log-ts" description:"Do not add a timestamp to logging"`
 		LogJson             bool          `long:"log-json" description:"Log in JSON format"`
 		DisableKeepAlivesFE bool          `long:"no-fk" description:"Disable frontend http keep-alive support"`
@@ -343,7 +344,9 @@ func main() {
 		// exvar, as it auto-adds it to the default servemux. Since we want
 		// to avoid it being available that when metrics is not enabled, we add
 		// it in manually only if metrics IS enabled.
-		mux.Handle("/debug/vars", expvar.Handler())
+		if !opts.NoDebugVars {
+			mux.Handle("/debug/vars", expvar.Handler())
+		}
 		mux.Handle("/metrics", promhttp.Handler())
 	}
 


### PR DESCRIPTION
### Description

Fixes #66

### Checklist

- [x] Code compiles correctly
- [ ] Created tests (if appropriate)
- [ ] All tests passing
- [x] Extended the README / documentation (if necessary)

