### PR TITLE
Fixed a typo in the readme file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -465,7 +465,7 @@ In addition, a number of custom metrics.
 | The number of responses that failed to send to the client.
 
 | camo_proxy_reponses_truncated_total | Counter
-| The number of responess that were too large to send.
+| The number of responses that were too large to send.
 
 | camo_responses_total | Counter
 | Total HTTP requests processed by the go-camo, excluding scrapes.


### PR DESCRIPTION
### Description
This PR corrects a spelling error in the readme.adoc file. 
"responess" -> "responses"
Please explain the changes you made here.

### Checklist

- [ ] Code compiles correctly
- [ ] Created tests (if appropriate)
- [ ] All tests passing
- [x] Extended the README / documentation (if necessary)

