### PR TITLE
Implement optional redirect when max-size is exceeded

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -302,6 +302,7 @@ Flags:
       --ssl-key=STRING           ssl private key (key.pem) path
       --ssl-cert=STRING          ssl cert (cert.pem) path
       --max-size=INT-64          Max allowed response size (KB)
+      --max-size-redirect        URL to redirect to when max-size is exceeded
       --timeout=4s               Upstream request timeout
       --max-redirects=3          Maximum number of redirects to follow
       --metrics                  Enable Prometheus compatible metrics endpoint

--- a/cmd/go-camo/main.go
+++ b/cmd/go-camo/main.go
@@ -81,6 +81,7 @@ type CLI struct {
 	MaxSize             int64         `name:"max-size" help:"Max allowed response size (KB)"`
 	ReqTimeout          time.Duration `name:"timeout" default:"4s" help:"Upstream request timeout"`
 	MaxRedirects        int           `name:"max-redirects" default:"3" help:"Maximum number of redirects to follow"`
+	MaxSizeRedirect     string        `long:"max-size-redirect" description:"URL to redirect when max-size is exceeded"`
 	Metrics             bool          `name:"metrics" help:"Enable Prometheus compatible metrics endpoint"`
 	NoDebugVars         bool          `name:"no-debug-vars" help:"Disable the /debug/vars/ metrics endpoint. This option has no effects when the metrics are not enabled."`
 	NoLogTS             bool          `name:"no-log-ts" help:"Do not add a timestamp to logging"`
@@ -227,6 +228,7 @@ func (cli *CLI) Run() {
 	config.MaxSize = cli.MaxSize * 1024
 	config.RequestTimeout = cli.ReqTimeout
 	config.MaxRedirects = cli.MaxRedirects
+        config.MaxSizeRedirect = cli.MaxSizeRedirect
 	config.ServerName = ServerName
 
 	// configure metrics collection in camo

--- a/pkg/camo/proxy.go
+++ b/pkg/camo/proxy.go
@@ -36,6 +36,8 @@ type Config struct {
 	HMACKey []byte
 	// MaxSize is the maximum valid image size response (in bytes).
 	MaxSize int64
+	// MaxSizeRedirect is the URL to redirect when MaxSize is exceeded.
+	MaxSizeRedirect string
 	// MaxRedirects is the maximum number of redirects to follow.
 	MaxRedirects int
 	// Request timeout is a timeout for fetching upstream data.
@@ -246,7 +248,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if mlog.HasDebug() {
 			mlog.Debugx("content length exceeded", mlog.A("url", sURL))
 		}
-		http.Error(w, "Content length exceeded", http.StatusNotFound)
+		if p.config.MaxSizeRedirect != "" {
+			http.Redirect(w, req, p.config.MaxSizeRedirect, http.StatusFound)
+		} else {
+			http.Error(w, "Content length exceeded", http.StatusNotFound)
+		}
 		return
 	}
 


### PR DESCRIPTION
### Description

For [our](https://pypi.org) use-case, we prefer to display a static image, indicating why the image is not loading, namely:

![PyPI Image Too Large Image](https://warehouse-camo.ingress.us-east-2.pypi.io/d1e139dd79d95783a48690c79813071314e45a69/68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f707970692d6173736574732f696d6167652d746f6f2d6c617267652d31306d622e706e67)

This is now one of the only divergences that aren't deployment centric in our fork of go-camo, so I'd be happy to do whatever is necessary to get it merged so we can just run from published images :)

### Checklist

- [x] Code compiles correctly
- [ ] Created tests (if appropriate)
- [x] All tests passing
- [x] Extended the README / documentation (if necessary)

